### PR TITLE
[Task] : Fix LIT test + disable pass failure for unlowered torch ops.

### DIFF
--- a/include/torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h
+++ b/include/torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h
@@ -26,6 +26,9 @@ void getBackendTypeConversionDependentDialects(DialectRegistry &registry);
 void setupBackendTypeConversion(ConversionTarget &target,
                                 TypeConverter &typeConverter);
 
+void setupBackendTypeConversionForTosaLinalg(ConversionTarget &target,
+                                             TypeConverter &typeConverter);
+
 #ifdef TORCH_MLIR_ENABLE_STABLEHLO
 void setupBackendTypeConversionForStablehlo(ConversionTarget &target,
                                             TypeConverter &typeConverter);

--- a/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h
+++ b/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h
@@ -99,6 +99,12 @@ createVerifyLinalgOnTensorsBackendContractPass();
 std::unique_ptr<OperationPass<ModuleOp>>
 createVerifyTosaLinalgBackendContractPass();
 
+std::unique_ptr<OperationPass<ModuleOp>>
+createFuncBackendTypeConversionForTosaLinalgPass();
+
+std::unique_ptr<InterfacePass<FunctionOpInterface>>
+createFinalizingBackendTypeConversionForTosaLinalgPass();
+
 } // namespace TorchConversion
 
 /// Registers all Torch transformation passes.

--- a/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.td
+++ b/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.td
@@ -73,6 +73,26 @@ def VerifyTosaLinalgBackendContract : Pass<"torch-verify-tosa-linalg-backend-con
   let constructor = "mlir::torch::TorchConversion::createVerifyTosaLinalgBackendContractPass()";
 }
 
+def FinalizingBackendTypeConversionForTosaLinalg
+    : InterfacePass<"torch-finalizing-backend-type-conversion-for-tosa-linalg", "mlir::FunctionOpInterface"> {
+  let summary = "Finalizes a partial conversion to builtin tensors for tosa+linalg";
+  let constructor =
+    "mlir::torch::TorchConversion::createFinalizingBackendTypeConversionForTosaLinalgPass()";
+  let description = [{
+    Analogous in scope to the upstream `finalizing-bufferize` pass.
+    See details there.
+  }];
+}
+
+def FuncBackendTypeConversionForTosaLinalg : Pass<"torch-func-backend-type-conversion-for-tosa-linalg", "ModuleOp"> {
+  let summary = "Convert functions to operate on builtin tensors for tosa+linalg backend";
+  let constructor = "mlir::torch::TorchConversion::createFuncBackendTypeConversionForTosaLinalgPass()";
+  let description = [{
+    Partial type conversion pass analogous in scope to the upstream
+    `func-bufferize` pass. See details there.
+  }];
+}
+
 #ifdef TORCH_MLIR_ENABLE_STABLEHLO
 def VerifyStablehloBackendContract : Pass<"torch-verify-stablehlo-backend-contract", "ModuleOp"> {
   let summary = "Verifies conformity to the stablehlo backend contract";

--- a/lib/Conversion/TorchToTosaLinalg/TorchToTosaLinalg.cpp
+++ b/lib/Conversion/TorchToTosaLinalg/TorchToTosaLinalg.cpp
@@ -65,7 +65,8 @@ public:
 
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type type) { return type; });
-    TorchConversion::setupBackendTypeConversion(target, typeConverter);
+    TorchConversion::setupBackendTypeConversionForTosaLinalg(target,
+                                                             typeConverter);
 
     RewritePatternSet patterns(context);
 

--- a/lib/Dialect/TorchConversion/Transforms/Passes.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/Passes.cpp
@@ -199,15 +199,12 @@ void TorchConversion::createTorchBackendToTosaLinalgBackendPipeline(
 
   // Finish the type conversion from `torch` types to the types of the
   // TOSA backend contract.
-  pm.addPass(TorchConversion::createFuncBackendTypeConversionPass());
+  pm.addPass(
+      TorchConversion::createFuncBackendTypeConversionForTosaLinalgPass());
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   pm.addNestedPass<func::FuncOp>(
-      TorchConversion::createFinalizingBackendTypeConversionPass());
-
-  // Verify that we have lowered to ops that are supported by union of TOSA and
-  // Linalg-on-tensors backend. This fails compilation (signalPassFailure) if
-  // the IR is not in the correct form.
-  pm.addPass(TorchConversion::createVerifyTosaLinalgBackendContractPass());
+      TorchConversion::
+          createFinalizingBackendTypeConversionForTosaLinalgPass());
 }
 #endif
 

--- a/python/torch_mlir/fx_mw.py
+++ b/python/torch_mlir/fx_mw.py
@@ -15,6 +15,7 @@ from .compiler_utils_mw import (
 from . import fx
 from torch._decomp import get_decompositions
 
+
 def import_exported_model(
     prog: torch.export.ExportedProgram,
     output_type: str,
@@ -32,10 +33,11 @@ def import_exported_model(
         experimental_support_mutation=experimental_support_mutation,
     )
 
-    if output_type != 'raw':
+    if output_type != "raw":
         mlir_module = lower_module(mlir_module, output_type)
 
     return mlir_module
+
 
 def lower_module_from_file(mlir_file: str, output_type: str):
     src = open(mlir_file, "r").read()
@@ -43,8 +45,9 @@ def lower_module_from_file(mlir_file: str, output_type: str):
         torch_mlir.dialects.torch.register_dialect(ctx)
         with torch_mlir.ir.Location.unknown() as loc:
             mlir_module = torch_mlir.ir.Module.parse(src)
-    
+
     return lower_module(mlir_module, output_type)
+
 
 def lower_module(mlir_module, output_type: str):
 
@@ -62,7 +65,8 @@ def lower_module(mlir_module, output_type: str):
                 "aten.adaptive_avg_pool2d",
                 "aten.adaptive_max_pool1d",
                 "aten.adaptive_max_pool2d",
-                "aten.linear"]
+                "aten.linear",
+            ]
         case "linalg_on_tensors":
             output_type = OutputType.LINALG_ON_TENSORS
             backend_legal_ops = [
@@ -70,9 +74,9 @@ def lower_module(mlir_module, output_type: str):
                 "aten.adaptive_avg_pool1d",
                 "aten.adaptive_avg_pool2d",
                 "aten.adaptive_max_pool1d",
-                "aten.adaptive_max_pool2d",                
+                "aten.adaptive_max_pool2d",
                 "aten.unflatten.int",
-                ]
+            ]
         case "tosa_linalg":
             output_type = OutputType.TOSA_LINALG
             backend_legal_ops = [
@@ -83,12 +87,13 @@ def lower_module(mlir_module, output_type: str):
                 "aten.adaptive_max_pool1d",
                 "aten.adaptive_max_pool2d",
                 "aten.linear",
-                "aten.unflatten.int"]
+                "aten.unflatten.int",
+            ]
         case "raw":
             output_type = OutputType.RAW
         case _:
             raise ValueError("Importing PyTorch model failed: Unsupported output type.")
-        
+
     backend_legal_op_arg_str = ""
     if backend_legal_ops is not None:
         if not len(backend_legal_ops) == 0:

--- a/python/torch_mlir/fx_mw.py
+++ b/python/torch_mlir/fx_mw.py
@@ -4,6 +4,7 @@
 # Also available under a BSD-style license. See LICENSE.
 
 import torch
+import torch_mlir
 from .compiler_utils import OutputType
 
 from .compiler_utils_mw import (
@@ -24,6 +25,28 @@ def import_exported_model(
         [torch.ops.aten.lstm.input, torch.ops.aten.gru.input]
     )
     prog = prog.run_decompositions(decomp_table)
+
+    mlir_module = fx.export_and_import(
+        prog,
+        output_type=OutputType.RAW,
+        experimental_support_mutation=experimental_support_mutation,
+    )
+
+    if output_type != 'raw':
+        mlir_module = lower_module(mlir_module, output_type)
+
+    return mlir_module
+
+def lower_module_from_file(mlir_file: str, output_type: str):
+    src = open(mlir_file, "r").read()
+    with torch_mlir.ir.Context() as ctx:
+        torch_mlir.dialects.torch.register_dialect(ctx)
+        with torch_mlir.ir.Location.unknown() as loc:
+            mlir_module = torch_mlir.ir.Module.parse(src)
+    
+    return lower_module(mlir_module, output_type)
+
+def lower_module(mlir_module, output_type: str):
 
     backend_legal_ops = None
 
@@ -65,36 +88,28 @@ def import_exported_model(
             output_type = OutputType.RAW
         case _:
             raise ValueError("Importing PyTorch model failed: Unsupported output type.")
+        
+    backend_legal_op_arg_str = ""
+    if backend_legal_ops is not None:
+        if not len(backend_legal_ops) == 0:
+            backend_legal_op_arg_str = "backend-legal-ops=" + ",".join(
+                backend_legal_ops
+            )
 
-    mlir_module = fx.export_and_import(
-        prog,
-        output_type=OutputType.RAW,
-        experimental_support_mutation=experimental_support_mutation,
+    extra_library_file_name = ""
+    option_string = (
+        "{"
+        + backend_legal_op_arg_str
+        + " extra-library="
+        + extra_library_file_name
+        + "}"
+    )
+    run_pipeline_mw(
+        mlir_module,
+        f"builtin.module(func.func(torch-match-quantized-custom-ops), torchdynamo-export-to-torch-backend-pipeline{option_string})",
+        "Lowering TorchFX IR -> Torch Backend IR",
+        enable_ir_printing=False,
     )
 
-    if output_type != OutputType.RAW:
-        backend_legal_op_arg_str = ""
-        if backend_legal_ops is not None:
-            if not len(backend_legal_ops) == 0:
-                backend_legal_op_arg_str = "backend-legal-ops=" + ",".join(
-                    backend_legal_ops
-                )
-
-        extra_library_file_name = ""
-        option_string = (
-            "{"
-            + backend_legal_op_arg_str
-            + " extra-library="
-            + extra_library_file_name
-            + "}"
-        )
-        run_pipeline_mw(
-            mlir_module,
-            f"builtin.module(func.func(torch-match-quantized-custom-ops), torchdynamo-export-to-torch-backend-pipeline{option_string})",
-            "Lowering TorchFX IR -> Torch Backend IR",
-            enable_ir_printing=False,
-        )
-        verbose = False
-        mlir_module = lower_mlir_module_mw(verbose, output_type, mlir_module)
-
-    return mlir_module
+    verbose = False
+    return lower_mlir_module_mw(verbose, output_type, mlir_module)

--- a/test/Conversion/TorchToTosa/basic.mlir
+++ b/test/Conversion/TorchToTosa/basic.mlir
@@ -2149,7 +2149,7 @@ func.func @torch.aten.diagonal$basic(%arg0: !torch.vtensor<[3,4,5,6], si32>) -> 
 // CHECK:           %[[VAL_10:.*]] = tosa.greater %[[VAL_5]], %[[VAL_9]] : (tensor<2xi32>, tensor<1xi32>) -> tensor<2xi1>
 // CHECK:           %[[VAL_11:.*]] = tosa.const_shape  {values = dense<1> : tensor<1xindex>} : () -> !tosa.shape<1>
 // CHECK:           %[[VAL_12:.*]] = tosa.reshape %[[VAL_6]], %[[VAL_11]] : (tensor<i32>, !tosa.shape<1>) -> tensor<1xi32>
-// CHECK:           %[[VAL_13:.*]] = tosa.int_div %[[VAL_5]], %[[VAL_12]] : (tensor<2xi32>, tensor<1xi32>) -> tensor<2xi32>
+// CHECK:           %[[VAL_13:.*]] = tosa.intdiv %[[VAL_5]], %[[VAL_12]] : (tensor<2xi32>, tensor<1xi32>) -> tensor<2xi32>
 // CHECK:           %[[VAL_14:.*]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}> : () -> tensor<1xi8>
 // CHECK:           %[[VAL_15:.*]] = tosa.mul %[[VAL_13]], %[[VAL_13]], %[[VAL_14]] : (tensor<2xi32>, tensor<2xi32>, tensor<1xi8>) -> tensor<2xi32>
 // CHECK:           %[[VAL_16:.*]] = tosa.sub %[[VAL_5]], %[[VAL_15]] : (tensor<2xi32>, tensor<2xi32>) -> tensor<2xi32>
@@ -3920,11 +3920,11 @@ func.func @torch.aten.convolution$full_dim_indivisible_by_stride_without_sliced_
 // CHECK:           %[[VAL_11:.*]] = "tosa.const"() <{values = dense<0.000000e+00> : tensor<32xf32>}> : () -> tensor<32xf32>
 // CHECK:           %[[VAL_12:.*]] = tosa.transpose %[[VAL_1]] {perms = array<i32: 0, 2, 3, 1>} : (tensor<?x3x225x225xf32>) -> tensor<?x225x225x3xf32>
 // CHECK:           %[[VAL_13:.*]] = tosa.transpose %[[VAL_4]] {perms = array<i32: 0, 2, 3, 1>} : (tensor<32x3x3x3xf32>) -> tensor<32x3x3x3xf32>
-// CHECK:           %[[VAL_14:.*]] = tosa.const_shape  {values = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
-// CHECK:           %[[VAL_15:.*]] = tosa.const_shape  {values = dense<[-1, 224, 225, 3]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:           %[[VAL_14:.*]] = tosa.const_shape  {values = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:           %[[VAL_15:.*]] = tosa.const_shape  {values = dense<[-1, 224, 225, 3]> : tensor<4xindex>} : () -> !tosa.shape<4>
 // CHECK:           %[[VAL_16:.*]] = tosa.slice %[[VAL_12]], %[[VAL_14]], %[[VAL_15]] : (tensor<?x225x225x3xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<?x224x225x3xf32>
-// CHECK:           %[[VAL_17:.*]] = tosa.const_shape  {values = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
-// CHECK:           %[[VAL_18:.*]] = tosa.const_shape  {values = dense<[-1, 224, 224, 3]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:           %[[VAL_17:.*]] = tosa.const_shape  {values = dense<0> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG:           %[[VAL_18:.*]] = tosa.const_shape  {values = dense<[-1, 224, 224, 3]> : tensor<4xindex>} : () -> !tosa.shape<4>
 // CHECK:           %[[VAL_19:.*]] = tosa.slice %[[VAL_16]], %[[VAL_17]], %[[VAL_18]] : (tensor<?x224x225x3xf32>, !tosa.shape<4>, !tosa.shape<4>) -> tensor<?x224x224x3xf32>
 // CHECK:           %[[VAL_20:.*]] = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>
 // CHECK:           %[[VAL_21:.*]] = "tosa.const"() <{values = dense<0.000000e+00> : tensor<1xf32>}> : () -> tensor<1xf32>


### PR DESCRIPTION
1. Disabled `createVerifyTosaLinalgBackendContractPass` pass to avoid erroring out early. This will leave unsupported ops in the IR which we can then catch by "unregistered dialect" in our `cgir-mlir-opt` pass.
2. Added custom type conversion passes that keeps `uint8` as `uint8` similar to the `StableHloBackend`.
3. Added custom FinalizingBackendTypeConversionForTosaLinalg pass to do greedy pattern rewriting instead of full to avoid failures when some patterns cannot be replaced. `torch.constant.int` is one such op that will cause the pass to fail in full rewrite pass. Instead we only replace as much as we can and then report the unlowered ops from `cgir-mlir-opt`.
4. Refactored the `import_exported_program` call to be able to dump `raw` torch IR similar to how we dump `tfl` IR.